### PR TITLE
Allow S3 openapi to be nullable

### DIFF
--- a/lib/fishjam_web/api_spec/component/HLS/S3.ex
+++ b/lib/fishjam_web/api_spec/component/HLS/S3.ex
@@ -27,6 +27,7 @@ defmodule FishjamWeb.ApiSpec.Component.HLS.S3 do
         description: "The name of the S3 bucket where your data will be stored."
       }
     },
-    required: [:accessKeyId, :secretAccessKey, :region, :bucket]
+    required: [:accessKeyId, :secretAccessKey, :region, :bucket],
+    nullable: true
   })
 end

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -156,6 +156,7 @@ components:
       properties:
         credentials:
           description: An AWS S3 credential that will be used to send HLS stream. The stream will only be uploaded if credentials are provided
+          nullable: true
           properties:
             accessKeyId:
               description: An AWS access key identifier, linked to your AWS account.
@@ -443,6 +444,7 @@ components:
           type: boolean
         s3:
           description: An AWS S3 credential that will be used to send HLS stream. The stream will only be uploaded if credentials are provided
+          nullable: true
           properties:
             accessKeyId:
               description: An AWS access key identifier, linked to your AWS account.
@@ -500,6 +502,7 @@ components:
       x-struct: Elixir.FishjamWeb.ApiSpec.Component.SIP.SIPCredentials
     S3Credentials:
       description: An AWS S3 credential that will be used to send HLS stream. The stream will only be uploaded if credentials are provided
+      nullable: true
       properties:
         accessKeyId:
           description: An AWS access key identifier, linked to your AWS account.


### PR DESCRIPTION
## Acknowledging the stipulations set forth:
 - [x] I hereby confirm that a Pull Request involving updates to the Software Development Kit (SDK) has been smoothly merged, currently awaits processing, or is otherwise deemed unnecessary in this context.
 - [x] I also affirm that another Pull Request, specifically addressing updates to the documentation body (commonly referred to as 'docs'), has either been successfully incorporated, is in the process of review, or is considered superfluous under the prevailing circumstances.
